### PR TITLE
Fix the Commission bug

### DIFF
--- a/src/Lib/MTUserProtocol.php
+++ b/src/Lib/MTUserProtocol.php
@@ -1933,7 +1933,7 @@ class MTUserAccountAnswer
         $result->MarginLeverage    = (int)$obj->MarginLeverage;
         $result->Profit            = (float)$obj->Profit;
         $result->Storage           = (float)$obj->Storage;
-        $result->Commission        = (float)$obj->Commission;
+        $result->Commission        = isset($obj->Commission) ? (float)$obj->Commission : 0;
         $result->Floating          = (float)$obj->Floating;
         $result->Equity            = (float)$obj->Equity;
         $result->SOActivation      = (int)$obj->SOActivation;


### PR DESCRIPTION
Some Traders don't have Comission enables so when fetching the data from
MT5 it does not send the comission so it is throwing the exception.

I have added a check where it checks if commission isset.